### PR TITLE
Add wildcard selector for on change event listener to support additio…

### DIFF
--- a/Resources/views/fields.html.twig
+++ b/Resources/views/fields.html.twig
@@ -5,8 +5,22 @@
     <script type="text/javascript">
         jQuery(function(){
 
-            jQuery("input[id^={{ form.parent.offsetGet( parent_field ).vars.id }}], select[id^={{ form.parent.offsetGet( parent_field ).vars.id }}]").change( function() {
-                if (!jQuery(this).val()) {
+            var types = [
+                "{{ form.parent.offsetGet( parent_field ).vars.id }}",
+                "select#{{ form.parent.offsetGet( parent_field ).vars.id }}",
+                "{{ form.parent.offsetGet( parent_field ).vars.id }}" + '_autocomplete_input',
+            ]
+
+            types.forEach(function (type) {
+                if (document.getElementById(type)) {
+                    jQuery('#' + type).change(function () {
+                        onInputChange(jQuery(this));
+                    });
+                }
+            });
+
+            function onInputChange(element) {
+                if (!jQuery(element).val()) {
                     return;
                 }
 
@@ -14,7 +28,7 @@
                 jQuery.ajax({
                     type: "POST",
                     data: {
-                        parent_id: jQuery(this).val(),
+                        parent_id: jQuery(element).val(),
                         {% if fallback_parent_field is not null %}
                         fallback_parent_id: jQuery("#{{ form.parent.offsetGet( fallback_parent_field ).vars.id }}").val(),
                         {% endif %}
@@ -43,9 +57,9 @@
                         jQuery('html').html(xhr.responseText);
                     }
                 });
-            });
+            }
 
-            jQuery("select#{{ form.parent.offsetGet( parent_field ).vars.id }}").trigger('change');
+            jQuery("select#{{ form.parent.offsetGet( parent_field ).vars.id }}").trigger('change', onInputChange(this));
         });
     </script>
 

--- a/Resources/views/fields.html.twig
+++ b/Resources/views/fields.html.twig
@@ -5,7 +5,7 @@
     <script type="text/javascript">
         jQuery(function(){
 
-            jQuery("select#{{ form.parent.offsetGet( parent_field ).vars.id }}").change( function() {
+            jQuery("input[id^={{ form.parent.offsetGet( parent_field ).vars.id }}], select[id^={{ form.parent.offsetGet( parent_field ).vars.id }}]").change( function() {
                 if (!jQuery(this).val()) {
                     return;
                 }

--- a/Resources/views/fields.html.twig
+++ b/Resources/views/fields.html.twig
@@ -6,12 +6,20 @@
         jQuery(function(){
 
             var types = [
+                // Used to find any field matching the exact ID returned by the backend. Only one instance of this field
+                // should exist within the DOM.
                 "{{ form.parent.offsetGet( parent_field ).vars.id }}",
+                // Find all select types including default EntityType and additional Sonata types like ModelType
+                // Original default
                 "select#{{ form.parent.offsetGet( parent_field ).vars.id }}",
+                // Support for the Sonata ModelAutocompleteType. Field ID differs from the one returned by the backend
+                // therefore the below is necessary to find and watch it.
                 "{{ form.parent.offsetGet( parent_field ).vars.id }}" + '_autocomplete_input',
             ]
 
             types.forEach(function (type) {
+                // Where an element in the DOM with the ID exists, add an event listener to perform the dependent
+                // select AJAX call.
                 if (document.getElementById(type)) {
                     jQuery('#' + type).change(function () {
                         onInputChange(jQuery(this));
@@ -20,6 +28,7 @@
             });
 
             function onInputChange(element) {
+                // Keeps a field in a disabled state if the value is empty to prevent issues saving
                 if (!jQuery(element).val()) {
                     return;
                 }


### PR DESCRIPTION
DependentSelect was targetting the wrong field when using additional Sonta form field types such as `ModelAutocompleteType`. As a result, when using a `ModelAutocompleteType` and selecting a result, the dependent select field wouldn't see the change. 

This PR will wildcard and input or select elements with the ID starting:

`uniqueFormId_fieldName`
 
Giving a result:

`uniqueFormId_fieldName_*` 